### PR TITLE
Switch to using setup tools to list installed distributions

### DIFF
--- a/hitchsystem/commandline.py
+++ b/hitchsystem/commandline.py
@@ -7,6 +7,7 @@ import unixpackage
 import itertools
 import signal
 import pip
+import pkg_resources
 
 
 def _hitchpackage_specified_packages():
@@ -14,7 +15,7 @@ def _hitchpackage_specified_packages():
 
     # Get a list of all UNIXPACKAGES lists from installed packages starting with 'hitch'
     packages = []
-    for name in [dist.key for dist in pip.get_installed_distributions()]:
+    for name in [dist.key for dist in pkg_resources.working_set]:
         if name.startswith("hitch"):
             module = __import__(name)
 


### PR DESCRIPTION
Encountered issues running `hitch init` as part of a pathquery install. It turns out `get_installed_distributions` was removed in pip 10. As it was basically a wrapper around `pkg_resources` switched to using that instead.